### PR TITLE
Add auto-fill generation on 4-bar cycle

### DIFF
--- a/include/ghost_note.h
+++ b/include/ghost_note.h
@@ -3,3 +3,5 @@
 uint8_t *ghost_note_velocity_table(void);
 
 void ghost_note_create(track_t *track);
+
+void ghost_note_maintenance_step(void);

--- a/include/looper.h
+++ b/include/looper.h
@@ -50,12 +50,15 @@ typedef struct {
     bool pattern[LOOPER_TOTAL_STEPS];       // Current active pattern
     bool hold_pattern[LOOPER_TOTAL_STEPS];  // Temporary copy saved on button down.
     bool ghost_pattern[LOOPER_TOTAL_STEPS];
+    bool fill_pattern[LOOPER_TOTAL_STEPS];
 } track_t;
 
 
 void looper_status_led_init(void);
 
 looper_status_t *looper_status_get(void);
+
+track_t *looper_tracks_get(size_t *num_tracks);
 
 uint32_t looper_get_step_interval_ms(void);
 

--- a/src/ghost_note.c
+++ b/src/ghost_note.c
@@ -63,3 +63,29 @@ void ghost_note_create(track_t *track) {
     add_ghost_euclidean(track);
     add_ghost_flams(track);
 }
+
+void ghost_note_maintenance_step(void) {
+    looper_status_t *looper_status = looper_status_get();
+    size_t num_tracks;
+    track_t *tracks = looper_tracks_get(&num_tracks);
+
+    if (looper_status->current_step % (LOOPER_TOTAL_STEPS / 2) == 0)
+        looper_status->ghost_bar_counter = (looper_status->ghost_bar_counter + 1) % 4;
+
+    const uint16_t fill_start = (float)LOOPER_TOTAL_STEPS * (3.0 / 4);
+
+    if (looper_status->ghost_bar_counter == 0 && looper_status->current_step == 0) {
+        for (size_t i = 0; i < num_tracks; i++) {
+            ghost_note_create(&tracks[i]);
+            memset(tracks[i].fill_pattern, 0, sizeof(tracks[i].fill_pattern));
+        }
+    } else if (looper_status->ghost_bar_counter == 2 && looper_status->current_step == 0) {
+        for (size_t i = 0; i < num_tracks; i++) {
+            for (size_t f = fill_start; f < LOOPER_TOTAL_STEPS; f++) {
+                if (tracks[i].ghost_pattern[f]) {
+                    tracks[i].fill_pattern[f] = PROBABILITY(0.90);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces an auto-fill mechanism that enhances rhythmic variation by injecting a fill pattern during the last quarter of each 4-bar loop cycle. This helps create a more dynamic and "musical" phrasing in the looper output, especially when paired with ghost notes.

- Adds ghost_bar_counter to track 4-bar progress
- Adds fill_pattern as a separate output layer
- Introduces bar-aware logic in ghost_note_maintenance_step()
