### PR TITLE
Ghost parameter control via MIDI CC

### DIFF
--- a/include/ghost_note.h
+++ b/include/ghost_note.h
@@ -1,7 +1,36 @@
 #pragma once
 
+#include "looper.h"
+#include "ghost_note.h"
+
+typedef struct {
+    uint8_t k_max;
+    uint8_t k_sufficient;
+    float k_intensity;
+    float probability;
+} euclidean_parameters_t;
+
+typedef struct {
+    float post_probability;
+    float after_probability;
+} flams_parameters_t;
+
+typedef struct {
+    float start_mean;
+    float start_sd;
+    float probability;
+} fill_parameters_t;
+
+typedef struct {
+    flams_parameters_t flams;
+    euclidean_parameters_t euclidean;
+    fill_parameters_t fill;
+} ghost_parameters_t;
+
 uint8_t *ghost_note_velocity_table(void);
 
 void ghost_note_create(track_t *track);
 
 void ghost_note_maintenance_step(void);
+
+ghost_parameters_t *ghost_note_parameters(void);

--- a/src/ghost_note.c
+++ b/src/ghost_note.c
@@ -7,6 +7,21 @@
 
 #define PROBABILITY(p) ((rand() / (RAND_MAX + 1.0)) < (p))
 
+static ghost_parameters_t parameters = {
+    .flams = {
+        .post_probability = 0.70,
+        .after_probability = 0.30},
+    .euclidean = {
+        .k_max = 16,
+        .k_sufficient = 6,
+        .k_intensity = 0.60,
+        .probability = 0.70},
+    .fill = {
+        .start_mean = 15.0,
+        .start_sd = 5.0,
+        .probability = 0.75},
+};
+
 static uint8_t velocity_table[] = {
     0x20,  // track 1 - Kick
     0x25,  // track 2 - Snare
@@ -41,21 +56,6 @@ double rand_normal(double mu, double sigma2) {
     double sigma = sqrt(sigma2);
     return mu + sigma * rand_standard_normal();
 }
-
-static ghost_parameters_t parameters = {
-    .euclidean = {
-        .k_max = 16,
-        .k_sufficient = 6,
-        .k_intensity = 0.50,
-        .probability = 0.80},
-    .flams = {
-        .post_probability = 0.30,
-        .after_probability = 0.30},
-    .fill = {
-        .start_mean = 10.0,
-        .start_sd = 5.0,
-        .probability = 0.90},
-};
 
 static inline int clamp_int(int x, int lo, int hi) {
     if (x < lo)

--- a/src/ghost_note.c
+++ b/src/ghost_note.c
@@ -9,8 +9,8 @@
 
 static ghost_parameters_t parameters = {
     .flams = {
-        .post_probability = 0.70,
-        .after_probability = 0.30},
+        .post_probability = 0.30,
+        .after_probability = 0.70},
     .euclidean = {
         .k_max = 16,
         .k_sufficient = 6,
@@ -109,12 +109,12 @@ static void add_ghost_flams(track_t *track) {
         if (track->pattern[i] && !track->pattern[(i + 1) % LOOPER_TOTAL_STEPS] &&
             !track->ghost_pattern[i])
             track->ghost_pattern[(i + 1) % LOOPER_TOTAL_STEPS] =
-                PROBABILITY(flams->after_probability);
+                PROBABILITY(flams->post_probability);
         if (track->pattern[i] &&
             !track->pattern[(LOOPER_TOTAL_STEPS + i - 1) % LOOPER_TOTAL_STEPS] &&
             !track->ghost_pattern[i])
             track->ghost_pattern[(LOOPER_TOTAL_STEPS + i - 1) % LOOPER_TOTAL_STEPS] =
-                PROBABILITY(flams->post_probability);
+                PROBABILITY(flams->after_probability);
     }
 }
 

--- a/src/ghost_note.c
+++ b/src/ghost_note.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "looper.h"
+#include "ghost_note.h"
 
 #define PROBABILITY(p) ((rand() / (RAND_MAX + 1.0)) < (p))
 
@@ -28,7 +29,7 @@ static double rand_standard_normal(void) {
     do {
         u = rand() / (double)RAND_MAX * 2.0 - 1.0;
         v = rand() / (double)RAND_MAX * 2.0 - 1.0;
-        s = u*u + v*v;
+        s = u * u + v * v;
     } while (s >= 1.0 || s == 0.0);
 
     s = sqrt(-2.0 * log(s) / s);
@@ -41,21 +42,52 @@ double rand_normal(double mu, double sigma2) {
     return mu + sigma * rand_standard_normal();
 }
 
+static ghost_parameters_t parameters = {
+    .euclidean = {
+        .k_max = 16,
+        .k_sufficient = 6,
+        .k_intensity = 0.50,
+        .probability = 0.80},
+    .flams = {
+        .post_probability = 0.30,
+        .after_probability = 0.30},
+    .fill = {
+        .start_mean = 10.0,
+        .start_sd = 5.0,
+        .probability = 0.90},
+};
+
+static inline int clamp_int(int x, int lo, int hi) {
+    if (x < lo)
+        return lo;
+    if (x > hi)
+        return hi;
+    return x;
+}
+
 // euclidean rhythm algorithm
 static void add_ghost_euclidean(track_t *track) {
+    euclidean_parameters_t *euclidean = &parameters.euclidean;
+
     uint8_t k = 0;
     for (size_t i = 0; i < LOOPER_TOTAL_STEPS; i++) {
         if (track->pattern[i])
             k++;
     }
-    float density = (float)k / (float)LOOPER_TOTAL_STEPS;
-
     if (k == 0 || k >= LOOPER_TOTAL_STEPS)
         return;
 
+    uint8_t k_base = k;
+    uint8_t k_auto = 0;
+    if (k < euclidean->k_sufficient) {
+        float ratio = (euclidean->k_sufficient - k) / (float)euclidean->k_sufficient;
+        k_auto = ceilf(ratio * euclidean->k_intensity * (euclidean->k_max - k));
+    }
+    k = clamp_int(k_base + k_auto, 1, euclidean->k_max);
+
     uint8_t max_phase = LOOPER_TOTAL_STEPS / k;
     uint8_t phase = rand() % max_phase;
-
+    float density = (float)k / (float)LOOPER_TOTAL_STEPS;
     uint8_t bucket = 0;
     for (size_t i = 0; i < LOOPER_TOTAL_STEPS; i++) {
         bucket += k;
@@ -64,22 +96,25 @@ static void add_ghost_euclidean(track_t *track) {
             size_t pos = (i + phase) % LOOPER_TOTAL_STEPS;
 
             if (!track->pattern[pos] && !track->ghost_pattern[pos])
-                track->ghost_pattern[pos] = PROBABILITY(0.80 * (1.0f - density));
+                track->ghost_pattern[pos] = PROBABILITY(euclidean->probability * (1.0f - density));
         }
     }
 }
 
 // 1/16th positions around the user input
 static void add_ghost_flams(track_t *track) {
+    flams_parameters_t *flams = &parameters.flams;
+
     for (size_t i = 0; i < LOOPER_TOTAL_STEPS; i++) {
         if (track->pattern[i] && !track->pattern[(i + 1) % LOOPER_TOTAL_STEPS] &&
             !track->ghost_pattern[i])
-            track->ghost_pattern[(i + 1) % LOOPER_TOTAL_STEPS] = PROBABILITY(0.30);
+            track->ghost_pattern[(i + 1) % LOOPER_TOTAL_STEPS] =
+                PROBABILITY(flams->after_probability);
         if (track->pattern[i] &&
             !track->pattern[(LOOPER_TOTAL_STEPS + i - 1) % LOOPER_TOTAL_STEPS] &&
             !track->ghost_pattern[i])
             track->ghost_pattern[(LOOPER_TOTAL_STEPS + i - 1) % LOOPER_TOTAL_STEPS] =
-                PROBABILITY(0.30);
+                PROBABILITY(flams->post_probability);
     }
 }
 
@@ -91,6 +126,7 @@ void ghost_note_create(track_t *track) {
 }
 
 void ghost_note_maintenance_step(void) {
+    fill_parameters_t *fill = &parameters.fill;
     looper_status_t *looper_status = looper_status_get();
     size_t num_tracks;
     track_t *tracks = looper_tracks_get(&num_tracks);
@@ -104,12 +140,16 @@ void ghost_note_maintenance_step(void) {
             memset(tracks[i].fill_pattern, 0, sizeof(tracks[i].fill_pattern));
         }
     } else if (looper_status->ghost_bar_counter == 2 && looper_status->current_step == 0) {
-        uint16_t fill_start = LOOPER_TOTAL_STEPS - abs(rand_normal(10.0, 5.0));
+        uint16_t fill_start = LOOPER_TOTAL_STEPS - abs(rand_normal(fill->start_mean, fill->start_sd));
         for (size_t i = 0; i < num_tracks; i++) {
             for (size_t f = fill_start; f < LOOPER_TOTAL_STEPS; f++) {
                 if (tracks[i].ghost_pattern[f])
-                    tracks[i].fill_pattern[f] = PROBABILITY(0.90);
+                    tracks[i].fill_pattern[f] = PROBABILITY(fill->probability);
             }
         }
     }
+}
+
+ghost_parameters_t *ghost_note_parameters(void) {
+    return &parameters;
 }


### PR DESCRIPTION
Adds comprehensive MIDI-based control over all Ghost Looper parameters, allowing performers and installers to tweak algorithmic behavior entirely from their DAW.

## Changes

* Ghost note parameters
    * Euclidean: `k_max`, `k_sufficient`, `intensity`, `probability`
    * Flams: `post_probability`, `after_probability`
    * Fill: `start_mean`, `start_sd`, `probability`
  * Maps each to **CC #71–79**, scaled linearly to a 0–127 range.


In the future, once the parameters are finalized, this feature will be removed.