### PR TITLE
Added note scheduler for swing operation in slave mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${CMAKE_PROJECT_NAME}
   src/looper.c
   src/tap_tempo.c
   src/ghost_note.c
+  src/note_scheduler.c
 )
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(${CMAKE_PROJECT_NAME}

--- a/drivers/async_timer.c
+++ b/drivers/async_timer.c
@@ -16,7 +16,8 @@ static async_context_threadsafe_background_t tick_async_context;
 
 void async_timer_init(void) {
 #if !defined(CYW43_ENABLE_BLUETOOTH)
-    async_context_threadsafe_background_config_t config = async_context_threadsafe_background_default_config();
+    async_context_threadsafe_background_config_t config =
+        async_context_threadsafe_background_default_config();
     if (async_context_threadsafe_background_init(&tick_async_context, &config)) {
         ;
     }

--- a/drivers/ble_midi_noop.c
+++ b/drivers/ble_midi_noop.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include "pico/async_context.h"
 
 void ble_midi_init() { }

--- a/drivers/storage.c
+++ b/drivers/storage.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include <string.h>
 
 #include "hardware/flash.h"

--- a/drivers/usb_midi.c
+++ b/drivers/usb_midi.c
@@ -1,8 +1,13 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #include "bsp/board_api.h"
-#include "pico/bootrom.h"
-#include "tusb.h"
 #include "ghost_note.h"
 #include "looper.h"
+#include "pico/bootrom.h"
+#include "tusb.h"
 
 #define _PID_MAP(itf, n) ((CFG_TUD_##itf) << (n))
 #define USB_PID                                                                            \
@@ -51,21 +56,22 @@ enum {
 uint8_t const desc_configuration[] = {
     TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
     TUD_MIDI_DESCRIPTOR(ITF_NUM_MIDI, STRID_MIDI_IFACE, EPNUM_MIDI_OUT, (0x80 | EPNUM_MIDI_IN), 64),
-    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, STRID_CDC_IFACE, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, 64)};
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, STRID_CDC_IFACE, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT,
+                       EPNUM_CDC_IN, 64)};
 
 uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
     (void)index;
     return desc_configuration;
 }
 
-const char * const string_desc_arr[] = {
+const char *const string_desc_arr[] = {
     (const char[]){0x09, 0x04},  // 0: is supported language is English (0x0409)
     /* 1‑3 : generic device strings */
-    "TinyUSB",                   // 1: Manufacturer
-    "Pico MIDI Looper",          // 2: Product
-    "",                          // 3: Serial, dynamically generated
-    "Pico USB MIDI Interface",   // 4: iInterface (MIDI)
-    "Pico USB CDC Console",      // 5: iInterface (CDC)
+    "TinyUSB",                  // 1: Manufacturer
+    "Pico MIDI Looper",         // 2: Product
+    "",                         // 3: Serial, dynamically generated
+    "Pico USB MIDI Interface",  // 4: iInterface (MIDI)
+    "Pico USB CDC Console",     // 5: iInterface (CDC)
 };
 
 static uint16_t descriptor_string_buffer[32 + 1];
@@ -95,7 +101,8 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
             // Cap at max char
             chr_count = strlen(str);
             const size_t max_count =
-                sizeof(descriptor_string_buffer) / sizeof(descriptor_string_buffer[0]) - 1;  // -1 for string type
+                sizeof(descriptor_string_buffer) / sizeof(descriptor_string_buffer[0]) -
+                1;  // -1 for string type
             if (chr_count > max_count) {
                 chr_count = max_count;
             }
@@ -176,7 +183,8 @@ static void update_ghost_parameters(uint8_t channel, uint8_t cc, uint8_t value) 
             params->euclidean.k_max = (uint8_t)clamp((int)value, 1, params->euclidean.k_max);
             break;
         case MIDI_CC_SOUND_CONTROLLER3:  // euclidean k_sufficient (0-k_max)
-            params->euclidean.k_sufficient = (uint8_t)clamp((int)value, 0, params->euclidean.k_sufficient);
+            params->euclidean.k_sufficient =
+                (uint8_t)clamp((int)value, 0, params->euclidean.k_sufficient);
             break;
         case MIDI_CC_SOUND_CONTROLLER4:  // euclidean k_intensity (0.0-1.0)
             params->euclidean.k_intensity = value / 127.0f;
@@ -184,17 +192,17 @@ static void update_ghost_parameters(uint8_t channel, uint8_t cc, uint8_t value) 
         case MIDI_CC_SOUND_CONTROLLER5:  // euclidean probability (0.0-1.0)
             params->euclidean.probability = value / 127.0f;
             break;
-        case MIDI_CC_SOUND_CONTROLLER6:  // flame before_probability (0.0-1.0)
-            params->flams.before_probability = value / 127.0f;
+        case MIDI_CC_SOUND_CONTROLLER6:  // boundary before_probability (0.0-1.0)
+            params->boundary.before_probability = value / 127.0f;
             break;
-        case MIDI_CC_SOUND_CONTROLLER7:  // flame after_probability (0.0-1.0)
-            params->flams.after_probability = value / 127.0f;
+        case MIDI_CC_SOUND_CONTROLLER7:  // boundary after_probability (0.0-1.0)
+            params->boundary.after_probability = value / 127.0f;
             break;
         case MIDI_CC_SOUND_CONTROLLER8:  // fill start_mean (0.0-MAX_MEAN)
             params->fill.start_mean = (value / 127.0f) * 32;
             break;
         case MIDI_CC_SOUND_CONTROLLER9:  // fill start_sd (0.0-MAX_SD)
-            params->fill.start_sd   = (value / 127.0f) * 16;
+            params->fill.start_sd = (value / 127.0f) * 16;
             break;
         case MIDI_CC_SOUND_CONTROLLER10:  // fill probability (0.0-1.0)
             params->fill.probability = value / 127.0f;

--- a/include/drivers/async_timer.h
+++ b/include/drivers/async_timer.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include "pico/async_context.h"

--- a/include/drivers/display.h
+++ b/include/drivers/display.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include "looper.h"

--- a/include/drivers/led.h
+++ b/include/drivers/led.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 void led_init(void);

--- a/include/drivers/storage.h
+++ b/include/drivers/storage.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include "looper.h"

--- a/include/ghost_note.h
+++ b/include/ghost_note.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include "looper.h"
@@ -13,7 +18,7 @@ typedef struct {
 typedef struct {
     float before_probability;
     float after_probability;
-} flams_parameters_t;
+} boundary_parameters_t;
 
 typedef struct {
     uint8_t interval_bar;
@@ -26,7 +31,7 @@ typedef struct {
     float ghost_intensity;
     float swing_ratio;
     float swing_ratio_base;
-    flams_parameters_t flams;
+    boundary_parameters_t boundary;
     euclidean_parameters_t euclidean;
     fill_parameters_t fill;
 } ghost_parameters_t;
@@ -43,4 +48,4 @@ void ghost_note_maintenance_step(void);
 
 ghost_parameters_t *ghost_note_parameters(void);
 
-void ghost_note_set_fillin_queue(void);
+void ghost_note_set_pending_fill_request(void);

--- a/include/looper.h
+++ b/include/looper.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include "pico/async_context.h"
@@ -42,7 +47,7 @@ typedef enum {
  */
 typedef struct {
     uint32_t bpm;
-    uint32_t step_duration_ms;
+    uint32_t step_period_ms;
     looper_state_t state;          // Current looper mode (e.g. PLAYING, RECORDING).
     uint8_t current_track;         // Index of the active track (for recording or preview).
     uint8_t current_step;          // Index of the current step in the sequence loop.
@@ -77,8 +82,6 @@ void looper_status_led_init(void);
 looper_status_t *looper_status_get(void);
 
 track_t *looper_tracks_get(size_t *num_tracks);
-
-uint32_t looper_get_step_interval_ms(void);
 
 void looper_update_bpm(uint32_t bpm);
 

--- a/include/looper.h
+++ b/include/looper.h
@@ -94,3 +94,5 @@ void looper_handle_midi_start(void);
 void looper_handle_input(void);
 
 void looper_schedule_step_timer(void);
+
+void looper_perform_note(uint8_t channel, uint8_t note, uint8_t velocity);

--- a/include/note_scheduler.h
+++ b/include/note_scheduler.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include <stdbool.h>

--- a/include/note_scheduler.h
+++ b/include/note_scheduler.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void note_scheduler_start_timer(void);
+bool note_scheduler_schedule_note(uint64_t time_us, uint8_t channel, uint8_t note, uint8_t velocity);
+void note_scheduler_flush_notes(void);

--- a/include/note_scheduler.h
+++ b/include/note_scheduler.h
@@ -3,6 +3,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void note_scheduler_start_timer(void);
+void note_scheduler_init(void);
 bool note_scheduler_schedule_note(uint64_t time_us, uint8_t channel, uint8_t note, uint8_t velocity);
-void note_scheduler_flush_notes(void);
+void note_scheduler_dispatch_pending(void);

--- a/include/tap_tempo.h
+++ b/include/tap_tempo.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2025, Hiroyuki OYAMA
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 #pragma once
 
 #include <stdint.h>

--- a/src/looper.c
+++ b/src/looper.c
@@ -24,6 +24,7 @@
 #include "drivers/usb_midi.h"
 #include "ghost_note.h"
 #include "tap_tempo.h"
+#include "note_scheduler.h"
 
 enum {
     MIDI_CHANNEL1 = 0,
@@ -59,17 +60,34 @@ static bool looper_perform_ready(void) {
 }
 
 // Send a note event to the output destination.
-static void looper_perform_note(uint8_t channel, uint8_t note, uint8_t velocity) {
+void looper_perform_note(uint8_t channel, uint8_t note, uint8_t velocity) {
     usb_midi_send_note(channel, note, velocity);
     ble_midi_send_note(channel, note, velocity);
+}
+
+static void looper_schedule_note_now(uint8_t channel, uint8_t note, uint8_t velocity) {
+    uint64_t time_us = time_us_64();
+    note_scheduler_schedule_note(time_us, channel, note, velocity);
 }
 
 // Sends a MIDI click at specific steps to indicate rhythm.
 static void send_click_if_needed(void) {
     if ((looper_status.current_step % LOOPER_CLICK_DIV) == 0 && looper_status.current_step == 0)
-        looper_perform_note(MIDI_CHANNEL1, RIM_SHOT, 0x30);
+        looper_schedule_note_now(MIDI_CHANNEL1, RIM_SHOT, 0x30);
     else if ((looper_status.current_step % LOOPER_CLICK_DIV) == 0)
-        looper_perform_note(MIDI_CHANNEL1, RIM_SHOT, 0x10);
+        looper_schedule_note_now(MIDI_CHANNEL1, RIM_SHOT, 0x10);
+}
+
+static uint64_t looper_get_swing_offset_us(uint8_t step_index) {
+    ghost_parameters_t *params = ghost_note_parameters();
+    float swing_ratio = params->swing_ratio;
+    float pair_length = looper_status.step_duration_ms * 2.0f;
+
+    if (step_index % 2 == 1) {
+        float offset_ms = pair_length * (swing_ratio - 0.5f);
+        return (uint64_t)(offset_ms * 1000.0f);  // ms → us
+    }
+    return 0;
 }
 
 // Perform all note events for the current step across all tracks.
@@ -77,11 +95,15 @@ static void send_click_if_needed(void) {
 static void looper_perform_step(void) {
     ghost_parameters_t *params = ghost_note_parameters();
 
+    uint64_t now = time_us_64();
+    uint64_t swing_offset_us = looper_get_swing_offset_us(looper_status.current_step);
+
     for (uint8_t i = 0; i < NUM_TRACKS; i++) {
         bool note_on = tracks[i].pattern[looper_status.current_step];
         if (note_on) {
             uint8_t velocity = ghost_note_modulate_base_velocity(i, 0x7f, looper_status.lfo_phase);
-            looper_perform_note(tracks[i].channel, tracks[i].note, velocity);
+            note_scheduler_schedule_note(now + swing_offset_us, tracks[i].channel, tracks[i].note, velocity);
+
             if (i == looper_status.current_track)
                 led_set(1);
         } else if (i == looper_status.current_track) {
@@ -94,20 +116,23 @@ static void looper_perform_step(void) {
             (float)tracks[i].ghost_notes[looper_status.current_step].rand_sample / 100.0f;
 
         if (ghost_note_on && !tracks[i].fill_pattern[looper_status.current_step])
-            looper_perform_note(tracks[i].channel, tracks[i].note, ghost_note_velocity[i]);
+            note_scheduler_schedule_note(now + swing_offset_us, tracks[i].channel, tracks[i].note, ghost_note_velocity[i]);
         if (tracks[i].fill_pattern[looper_status.current_step] && !note_on)
-            looper_perform_note(tracks[i].channel, tracks[i].note, 0x7f);
+            note_scheduler_schedule_note(now + swing_offset_us, tracks[i].channel, tracks[i].note, 0x7f);
     }
 }
 
 // Perform note events for the current step while recording.
 // In recording mode, the status LED is always turned on.
 static void looper_perform_step_recording(void) {
+    uint64_t now = time_us_64();
+    uint64_t swing_offset_us = looper_get_swing_offset_us(looper_status.current_step);
+
     led_set(1);
     for (uint8_t i = 0; i < NUM_TRACKS; i++) {
         bool note_on = tracks[i].pattern[looper_status.current_step];
         if (note_on)
-            looper_perform_note(tracks[i].channel, tracks[i].note, 0x7f);
+            note_scheduler_schedule_note(now + swing_offset_us, tracks[i].channel, tracks[i].note, 0x7f);
     }
 }
 
@@ -122,19 +147,12 @@ static void looper_next_step(uint64_t now_us) {
  * The result is quantized to the nearest step relative to the last tick.
  */
 static uint8_t looper_quantize_step() {
-    ghost_parameters_t *setting = ghost_note_parameters();
-    float pair_length = looper_status.step_duration_ms * 2;
-    float step_duration_ms = looper_status.step_duration_ms;
     uint8_t previous_step =
         (looper_status.current_step + LOOPER_TOTAL_STEPS - 1) % LOOPER_TOTAL_STEPS;
-    if (previous_step % 2 == 0)
-        step_duration_ms = pair_length * (1.0f - setting->swing_ratio);
-    else
-        step_duration_ms = pair_length * setting->swing_ratio;
-
     int64_t delta_us =
         looper_status.timing.button_press_start_us - looper_status.timing.last_step_time_us;
 
+    float step_duration_ms = looper_status.step_duration_ms;
     // Convert to step offset using rounding (nearest step)
     int32_t relative_steps = (int32_t)round((double)delta_us / 1000.0 / step_duration_ms);
     uint8_t estimated_step =
@@ -218,7 +236,7 @@ void looper_process_state(uint64_t start_us) {
             break;
         case LOOPER_STATE_TRACK_SWITCH:
             looper_status.current_track = (looper_status.current_track + 1) % NUM_TRACKS;
-            looper_perform_note(MIDI_CHANNEL10, OPEN_HIHAT, 0x7f);
+            looper_schedule_note_now(MIDI_CHANNEL10, OPEN_HIHAT, 0x7f);
             looper_next_step(start_us);
             looper_status.state = LOOPER_STATE_PLAYING;
             break;
@@ -281,7 +299,7 @@ void looper_handle_button_event(button_event_t event) {
         case BUTTON_EVENT_DOWN:
             // Button pressed: start timing and preview sound
             looper_status.timing.button_press_start_us = time_us_64();
-            looper_perform_note(track->channel, track->note, 0x7f);
+            looper_schedule_note_now(track->channel, track->note, 0x7f);
             // Backup track pattern in case this press becomes a long-press (undo)
             memcpy(track->hold_pattern, track->pattern, LOOPER_TOTAL_STEPS);
             break;
@@ -306,12 +324,12 @@ void looper_handle_button_event(button_event_t event) {
         case BUTTON_EVENT_LONG_HOLD_RELEASE:
             // ≥2 s hold: enter Tap-tempo (no track switch)
             looper_status.state = LOOPER_STATE_TAP_TEMPO;
-            looper_perform_note(MIDI_CHANNEL10, OPEN_HIHAT, 0x7f);
+            looper_schedule_note_now(MIDI_CHANNEL10, OPEN_HIHAT, 0x7f);
             break;
         case BUTTON_EVENT_VERY_LONG_HOLD_RELEASE:
             // ≥5 s hold: clear track data
             looper_status.state = LOOPER_STATE_CLEAR_TRACKS;
-            looper_perform_note(MIDI_CHANNEL10, CYMBAL, 0x7f);
+            looper_schedule_note_now(MIDI_CHANNEL10, CYMBAL, 0x7f);
             break;
         default:
             break;
@@ -324,14 +342,7 @@ void looper_handle_tick(async_context_t *ctx, async_at_time_worker_t *worker) {
 
     looper_process_state(start_us);
 
-    ghost_parameters_t *setting = ghost_note_parameters();
-    float pair_length = looper_status.step_duration_ms * 2;
     float step_delay = looper_status.step_duration_ms;
-    if (looper_status.current_step % 2 == 0)
-        step_delay = pair_length * (1.0f - setting->swing_ratio);
-    else
-        step_delay = pair_length * setting->swing_ratio;
-
     uint64_t handler_delay_ms = (time_us_64() - start_us) / 1000;
     uint32_t delay =
         (handler_delay_ms >= (uint32_t)step_delay) ? 1 : (uint32_t)step_delay - handler_delay_ms;

--- a/src/main.c
+++ b/src/main.c
@@ -7,15 +7,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <stdio.h>
-#include "pico/stdlib.h"
 
+#include "drivers/async_timer.h"
+#include "drivers/ble_midi.h"
+#include "drivers/led.h"
+#include "drivers/storage.h"
+#include "drivers/usb_midi.h"
 #include "looper.h"
 #include "note_scheduler.h"
-#include "drivers/led.h"
-#include "drivers/ble_midi.h"
-#include "drivers/usb_midi.h"
-#include "drivers/async_timer.h"
-#include "drivers/storage.h"
+#include "pico/stdlib.h"
 
 /*
  * Entry point for the Pico MIDI Looper application.
@@ -35,15 +35,13 @@ int main(void) {
     // Async timer + sequencer tick setup
     async_timer_init();
     looper_schedule_step_timer();
-    note_scheduler_start_timer();
+    note_scheduler_init();
 
     printf("[MAIN] Pico MIDI Looper start\n");
     while (true) {
         looper_handle_input();
         usb_midi_task();
-
-        note_scheduler_flush_notes();
-        tight_loop_contents();
+        note_scheduler_dispatch_pending();
     }
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include "pico/stdlib.h"
 
 #include "looper.h"
+#include "note_scheduler.h"
 #include "drivers/led.h"
 #include "drivers/ble_midi.h"
 #include "drivers/usb_midi.h"
@@ -24,24 +25,25 @@
  *  - Button events (looper_handle_input) for user-driven updates
  */
 int main(void) {
-    stdio_init_all();
-    led_init();
-
     usb_midi_init();
     ble_midi_init();
+    stdio_init_all();
+    led_init();
 
     storage_load_tracks();
 
     // Async timer + sequencer tick setup
     async_timer_init();
     looper_schedule_step_timer();
+    note_scheduler_start_timer();
 
     printf("[MAIN] Pico MIDI Looper start\n");
     while (true) {
         looper_handle_input();
         usb_midi_task();
 
-        sleep_us(100);
+        note_scheduler_flush_notes();
+        tight_loop_contents();
     }
     return 0;
 }

--- a/src/note_scheduler.c
+++ b/src/note_scheduler.c
@@ -12,14 +12,14 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include "note_scheduler.h"
+
+#include "drivers/async_timer.h"
+#include "looper.h"
 #include "pico/multicore.h"
 #include "pico/time.h"
 
-#include "looper.h"
-#include "note_scheduler.h"
-#include "drivers/async_timer.h"
-
-#define MAX_SCHEDULED_NOTES 32
+#define MAX_SCHEDULED_NOTES 24
 
 // One-time pending note event to be dispatched from the main loop
 typedef struct {

--- a/src/note_scheduler.c
+++ b/src/note_scheduler.c
@@ -1,0 +1,75 @@
+#include <stdint.h>
+#include "pico/multicore.h"
+#include "pico/time.h"
+#include "note_scheduler.h"
+#include "looper.h"
+
+#define NOTE_TIMER_INTERVAL_US 1000
+#define MAX_SCHEDULED_NOTES 16
+
+typedef struct {
+    uint64_t time_us;
+    uint8_t channel;
+    uint8_t note;
+    uint8_t velocity;
+} note_scheduler_note_t;
+
+static repeating_timer_t note_timer;
+
+static note_scheduler_note_t note_queue[MAX_SCHEDULED_NOTES];
+static size_t note_queue_len = 0;
+static note_scheduler_note_t send_queue[MAX_SCHEDULED_NOTES];
+static size_t send_queue_len = 0;
+static critical_section_t send_queue_cs;
+
+static bool note_timer_callback(repeating_timer_t *t) {
+    (void)t;
+    uint64_t now = time_us_64();
+    for (size_t i = 0; i < note_queue_len;) {
+        if (note_queue[i].time_us <= now) {
+            critical_section_enter_blocking(&send_queue_cs);
+            if (send_queue_len < MAX_SCHEDULED_NOTES)
+                send_queue[send_queue_len++] = note_queue[i];
+            critical_section_exit(&send_queue_cs);
+
+            for (size_t j = i; j < note_queue_len - 1; j++) {
+                note_queue[j] = note_queue[j + 1];
+            }
+            if (note_queue_len > 0)
+                note_queue_len--;
+        } else {
+            i++;
+        }
+    }
+    return true;
+}
+
+void note_scheduler_start_timer(void) {
+    critical_section_init(&send_queue_cs);
+    add_repeating_timer_us(-NOTE_TIMER_INTERVAL_US, note_timer_callback, NULL, &note_timer);
+}
+
+bool note_scheduler_schedule_note(uint64_t time_us, uint8_t channel, uint8_t note, uint8_t velocity) {
+    uint32_t irq_state = save_and_disable_interrupts();
+
+    if (note_queue_len < MAX_SCHEDULED_NOTES) {
+        note_queue[note_queue_len++] = (note_scheduler_note_t){
+            .time_us = time_us,
+            .channel = channel,
+            .note = note,
+            .velocity = velocity
+        };
+        restore_interrupts(irq_state);
+        return true;
+    }
+    restore_interrupts(irq_state);
+    return false;
+}
+
+void note_scheduler_flush_notes(void) {
+    critical_section_enter_blocking(&send_queue_cs);
+    for (size_t i = 0; i < send_queue_len; i++)
+        looper_perform_note(send_queue[i].channel, send_queue[i].note, send_queue[i].velocity);
+    send_queue_len = 0;
+    critical_section_exit(&send_queue_cs);
+}

--- a/src/tap_tempo.c
+++ b/src/tap_tempo.c
@@ -11,11 +11,12 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include "tap_tempo.h"
+
 #include <stdbool.h>
 #include <stdint.h>
-#include "pico/time.h"
 
-#include "tap_tempo.h"
+#include "pico/time.h"
 
 // Configuration constants
 enum {


### PR DESCRIPTION
In order to avoid deadlock in USB stack, the note is not pronounced immediately upon interrupt, but is registered in the note pronunciation scheduler and pronounced from the main.